### PR TITLE
Allow the use of single quotes/apostrophes in prelim files.

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
@@ -34,7 +34,8 @@ output:
 # (e.g., abstract, acknowledgements) below or use code similar to line 25-26 
 # for the .RMD files. If you are NOT producing a PDF, delete or silence
 # lines 25-39 in this YAML header.
-abstract: '`r if(knitr:::is_latex_output()) paste(readLines(here::here("prelims", "00-abstract.Rmd")), collapse = "\n  ")`'
+abstract: |
+  `r if(knitr:::is_latex_output()) paste(readLines(here::here("prelims", "00-abstract.Rmd")), collapse = "\n  ")`
 # If you'd rather include the preliminary content in files instead of inline
 # like below, use a command like that for the abstract above.  Note that a tab 
 # is needed on the line after the `|`.

--- a/inst/rstudio/templates/project/resources/index.Rmd
+++ b/inst/rstudio/templates/project/resources/index.Rmd
@@ -34,7 +34,8 @@ output:
 # (e.g., abstract, acknowledgements) below or use code similar to line 25-26 
 # for the .RMD files. If you are NOT producing a PDF, delete or silence
 # lines 25-39 in this YAML header.
-abstract: '`r if(knitr:::is_latex_output()) paste(readLines(here::here("prelims", "00-abstract.Rmd")), collapse = "\n  ")`'
+abstract: |
+  `r if(knitr:::is_latex_output()) paste(readLines(here::here("prelims", "00-abstract.Rmd")), collapse = "\n  ")`
 # If you'd rather include the preliminary content in files instead of inline
 # like below, use a command like that for the abstract above.  Note that a tab 
 # is needed on the line after the `|`.


### PR DESCRIPTION
You can now use single quotes/apostrophes in prelim files such as `prelims/00-abstract.Rmd`, which used to break the project.

Here's how this process used to work:
- the R code is executed first (replacing `r [...]` with the text of the abstract)
- YAML processes everything inside single quotes. note that if the abstract has single quotes in it, the YAML "quoted block" will end early, causing a syntax error.

Now, we're using a YAML "block scalar", which doesn't allow escapaing and contains everything that's indented. Note how we indent every line of the read file to continue the scalar.